### PR TITLE
Fix code generated custom toJson function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,7 @@ async function transformFromSelectionToCodeGen(uri: Uri) {
 		.then(_ => {
 			let terminal = window.createTerminal("pub get");
 			terminal.show();
-			terminal.sendText("flutter pub run build_runner build");
+			terminal.sendText("flutter pub run build_runner build --delete-conflicting-outputs");
 		})
 		.catch(handleError);
 }
@@ -144,7 +144,7 @@ async function transformFromClipboardToCodeGen(uri: Uri) {
 		.then(_ => {
 			let terminal = window.createTerminal("pub get");
 			terminal.show();
-			terminal.sendText("flutter pub run build_runner build");
+			terminal.sendText("flutter pub run build_runner build --delete-conflicting-outputs");
 		})
 		.catch(handleError);
 }

--- a/src/syntax.ts
+++ b/src/syntax.ts
@@ -399,22 +399,22 @@ export class ClassDefinition {
   }
 
   _codeGenJsonParseFunc(): string {
-    return `factory ${this._name}.fromJson(Map<String, dynamic> json) => _$${this._name}FromJson(json);`;
+    return `\tfactory ${this._name}.fromJson(Map<String, dynamic> json) => _$${this._name}FromJson(json);`;
   }
 
   _codeGenJsonGenFunc(): string {
-    return `Map<String, dynamic> toJson() => _$${this._name}ToJson(this);`;
+    return `\tMap<String, dynamic> toJson() => _$${this._name}ToJson(this);`;
   }
 
   toCodeGenString(): string {
     if (this._privateFields) {
       return `${this._codeGenImportList()}@JsonSerializable()\nclass ${
         this._name
-      } {\n${this._fieldListCodeGen()}\n\n${this._defaultPrivateConstructor()}\n\n${this._gettersSetters()}\n\n${this._codeGenJsonParseFunc()}\n\n${this._jsonGenFunc()}\n}\n`;
+      } {\n${this._fieldListCodeGen()}\n\n${this._defaultPrivateConstructor()}\n\n${this._gettersSetters()}\n${this._codeGenJsonParseFunc()}\n\n${this._codeGenJsonGenFunc()}\n}\n`;
     } else {
       return `${this._codeGenImportList()}@JsonSerializable()\nclass ${
         this._name
-      } {\n${this._fieldListCodeGen()}\n\n${this._defaultConstructor()}\n\n${this._codeGenJsonParseFunc()}\n\n${this._jsonGenFunc()}\n}\n`;
+      } {\n${this._fieldListCodeGen()}\n\n${this._defaultConstructor()}\n\n${this._codeGenJsonParseFunc()}\n${this._codeGenJsonGenFunc()}\n}\n`;
     }
   }
 


### PR DESCRIPTION
When generating code with JsonSerializable, the generated `toJson` function is custom made and doesn't use the JsonSerializable.toJson generated function. 

This PR solves this and also introduces some styling to those functions. 

Also appends `--delete-conflicting-outputs` to the `flutter pub run build_runner build` command in the terminal so it can always be built