### PR TITLE
Some minor fixes

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -110,7 +110,7 @@ export function getTypeName(obj: any): string {
 
 export function navigateNode(astNode: ASTNode, path: string): ASTNode {
     let node: ASTNode;
-    if (astNode.type === "Object") {
+    if (astNode?.type === "Object") {
         var objectNode: ObjectNode = astNode as ObjectNode;
         var propertyNode = objectNode.children[0];
         if (propertyNode !== null) {
@@ -118,7 +118,7 @@ export function navigateNode(astNode: ASTNode, path: string): ASTNode {
             node = propertyNode.value;
         }
     }
-    if (astNode.type === "Array") {
+    if (astNode?.type === "Array") {
         var arrayNode: ArrayNode = astNode as ArrayNode;
         var index = +path ?? null;
         if (index !== null && arrayNode.children.length > index) {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -119,7 +119,8 @@ export async function createClass(
       const snakeClassName = changeCase.snakeCase(c.getName());
       const targetPath = `${targetDirectory}/models/${snakeClassName}.dart`;
       if (fs.existsSync(targetPath)) {
-        throw Error(`${snakeClassName}.dart already exists`);
+        handleError(Error(`${snakeClassName}.dart already exists`));
+		return;
       }
 
       fs.writeFile(

--- a/src/syntax.ts
+++ b/src/syntax.ts
@@ -305,7 +305,7 @@ export class ClassDefinition {
     if (!print) {
       return '';
     }
-    return `\t@override\n\tList<Object> get props => [\n\t\t${Array.from(this.fields.keys()).map((field) => `this.${field}`).join(',\n\t\t')}\n\t];`;
+    return `\t@override\n\tList<Object> get props => [\n\t\t${Array.from(this.fields.keys()).map((field) => `this.${fixFieldName(field, this._privateFields)}`).join(',\n\t\t')}\n\t];`;
   }
 
   private _finalFieldKeyword(): string {


### PR DESCRIPTION
Introduces some minor fixes to the extension

 - Files stop generating when some dart file is duplicated
The models stop being generated when a dart model file is already present in the _models/_ folder because of an error thrown that stopped the iteration. This approach only shows an error message and continues the iteration without stopping the files from being generated.

- Field names are bad formatted in the equatable related `props` override
This one's on me. I didn't fixed the names for the `props` list generated for the equatable override. This PR fixes it.

- Cannot read type of undefined
I think this can fully or partially fix #3. I'm not sure but I'd like some of your help because you know better the tool and understand what behaviour could present the fix that I propose. Check the 113 and 121 lines of _src/helper.ts_. I'm just wrapping the equality check in the null safe operator so if the astNode is null, the function returns the node, that is `null`, I think. 
I'd like some retro on this so if you can spare some time, It'd be really helpful.