### PR TITLE
Use original case of json fields

### DIFF
--- a/src/syntax.ts
+++ b/src/syntax.ts
@@ -298,7 +298,8 @@ export class ClassDefinition {
     sb += `\tconst factory ${this._name}({\n`;
     for (var [key, value] of this.fields) {
       const fieldName = fixFieldName(key, this._name, this._privateFields);
-      sb += "\t\t" + this._addTypeDef(value) + ` ${fieldName},\n`;
+      sb += "\t\t" + `@JsonKey(name: "${key}")`;
+      sb += " " + this._addTypeDef(value) + ` ${fieldName},\n`;
     };
     sb += `\t}) = _${this._name};\n\n`;
     sb += `${this._codeGenJsonParseFunc(true)}`;


### PR DESCRIPTION
Fixes #12 

I have only included this change for freezed classes only. This will add `@JsonKey(name:'')` before each key respecting the original case

Sample:
```
    @JsonKey(name: "isSkippable") bool isSkippable,
    @JsonKey(name: "isOnetime") bool isOnetime,
    @JsonKey(name: "Disable") bool disable,
    @JsonKey(name: "Deleted") String deleted,
```

Note **disable, deleted** keys case