### PR TITLE
Fix nested array not generating properly

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -185,7 +185,7 @@ export function mergeObjectList(list: Array<any>, path: string, idx = -1): WithW
                     } else if (v instanceof Object && Array) {
                         var l = Array.from(obj.get(k));
                         var beginIndex = l.length;
-                        l.push(v);
+                        //l.push(v);
                         //TODO: bug: awaiting response from the author of the report.
                         var mergeableType = mergeableListType(l);
                         if (ListType.Object === mergeableType.listType) {


### PR DESCRIPTION
```
{
  "NoSalesReasons": [
    {
      "MainReason": "PRODUCT RELATED ISSUE",
      "ChildStatement": "Which out of following best describes the reason for product related issue ?",
      "ChildReasonChoices": [
        "Product Complaint",
        "Low Shelf Offtake",
        "Expiry Issue"
      ]
    }
  ]
}
```
Nested Array such as in **ChildReasonChoices** are not generated properly. Instead of `List<String>` data type of ChildReasonChoices, `List<ChildReasonChoices>` data type is generated, causing errors.

This PR attempts to fix nested array by commenting out a line in `helper.ts`.  
`l.push(v);` causes incorrect data type of the element inserted which makes array `[ String, String,String, [String, String,String ] ]`thereby making `mergeableListType` function to return incorrect data type (ie of the last element inserted which is array)